### PR TITLE
updated JRE version

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG java_image_tag=17-jre
+ARG java_image_tag=17-jre-jammy
 FROM eclipse-temurin:${java_image_tag}
 
 # -- Layer: Image Metadata


### PR DESCRIPTION
Update JRE version to use jammy distribution for better compatibility. Issue #24 @ https://github.com/PacktPublishing/Data-Engineering-with-Databricks-Cookbook/issues/24 points out the current problem. 